### PR TITLE
init of the smartdoge

### DIFF
--- a/devtool/iso/assemble.sh
+++ b/devtool/iso/assemble.sh
@@ -21,6 +21,9 @@ cp -rvL isomnt/* cdrom/
 # copy dogeos boot_archive
 cp -rvL $BOOT_ARCHIVE_DIR/boot_archive* ./amd64/
 
+# copy extra files
+cp -rvL ../../../extra/* ./cdrom/ # we are in build/dist/iso/
+
 # gen iso
 LC_ALL=C mkisofs -R -b boot/grub/stage2_eltorito --follow-links -no-emul-boot -boot-load-size 4 -boot-info-table -quiet -o ${DOGEOS_VER}.iso cdrom/
 

--- a/devtool/usb/assemble.sh
+++ b/devtool/usb/assemble.sh
@@ -60,6 +60,9 @@ cp boot_archive u/platform/i86pc/amd64
 cp boot_archive.hash u/platform/i86pc/amd64
 cp -rv usbmnt/boot u/
 
+# copy extra files
+cp -rvL ../../../extra/* ./cdrom/ # we are in build/dist/usb/
+
 # enable boot
 umount u
 lofiadm -d $udev

--- a/extra/smartdoge-install.sh
+++ b/extra/smartdoge-install.sh
@@ -1,0 +1,60 @@
+MEDIAPATH=$(readlink -e $(dirname $0)) # iso media mounted path
+
+rm -rf /opt/dogeos; mkdir -p /opt/dogeos
+cd /opt/dogeos
+
+# step 0: copy the boot_archive
+mkdir ./tmp
+cp -v $MEDIAPATH/platform/i86pc/amd64/boot_archive ./tmp
+
+# step 1: copy all dogeos files
+badev=$(lofiadm -a ./tmp/boot_archive)
+rm -rf ./tmp/bamnt; mkdir -p ./tmp/bamnt
+mount $badev ./tmp/bamnt
+rsync -avz ./tmp/bamnt/dogeos/* ./
+umount ./tmp/bamnt
+lofiadm -d $badev
+
+# step 2: copy all resources into right places
+rsync -avz $MEDIAPATH/dogeos ./mnt/dogeos-extra/
+
+# step 3: mark this as smartdoge
+touch ./smartdoge
+
+# step 4: link /opt/dogeos -> /dogeos and make it persistent
+ln -nsf /opt/dogeos /dogeos
+DOGEOS_CUSTOM_SMF="<?xml version='1.0'?>
+<!DOCTYPE service_bundle SYSTEM '/usr/share/lib/xml/dtd/service_bundle.dtd.1'>
+<service_bundle type='manifest' name='export'>
+  <service name='site/smartdoge' type='service' version='0'>
+    <create_default_instance enabled='true'/>
+    <single_instance/>
+    <dependency name='network' grouping='require_all' restart_on='error' type='service'>
+      <service_fmri value='svc:/milestone/network:default'/>
+    </dependency>
+    <dependency name='filesystem' grouping='require_all' restart_on='error' type='service'>
+      <service_fmri value='svc:/system/filesystem/local'/>
+    </dependency>
+    <method_context/>
+    <exec_method name='start' type='method' exec='ln -nsf /opt/dogeos /dogeos' timeout_seconds='60'/>
+    <exec_method name='stop' type='method' exec=':kill' timeout_seconds='60'/>
+    <property_group name='startd' type='framework'>
+      <propval name='duration' type='astring' value='transient'/>
+      <propval name='ignore_error' type='astring' value='core,signal'/>
+    </property_group>
+    <property_group name='application' type='application'/>
+    <stability value='Evolving'/>
+    <template>
+      <common_name>
+        <loctext xml:lang='C'>Link root .bashrc to /opt/custom/.bashrc</loctext>
+      </common_name>
+    </template>
+  </service>
+</service_bundle>"
+mkdir -p /opt/custom/smf
+echo $DOGEOS_CUSTOM_SMF >/opt/custom/smf/smartdoge.xml
+
+# final: clear all tmp files
+rm -rf ./tmp
+
+cd -

--- a/overlay/dogeos/bin/common.sh
+++ b/overlay/dogeos/bin/common.sh
@@ -197,10 +197,14 @@ dogeosGetAdminNicMac()
 # decide live media type, return in $val
 dogeosFindLiveMediaType()
 {
+  val="dvd"
   if [ -f /dogeos/liveusb ]; then
     val="usb"
-  else
-    val="dvd"
+    return
+  fi
+  if [ -f /dogeos/smartdoge ]; then
+    val="smartdoge"
+    return
   fi
 }
 

--- a/overlay/dogeos/bin/fifozone-install
+++ b/overlay/dogeos/bin/fifozone-install
@@ -42,10 +42,14 @@ dogeosPrepareResources()
 {
   echo "Start preparing resources in $DOGEOS_EXTRA ... "
   mkdir -p $DOGEOS_EXTRA
-  if [ "$live_media" == "usb" ]; then
-    mount -F pcfs ${live_media_path/rdsk/dsk}:c $DOGEOS_EXTRA
-  else # dvd
-    mount -F hsfs ${live_media_path/rdsk/dsk} $DOGEOS_EXTRA
+  if [ "$live_media" == "smartdoge" ]; then
+    echo "Smartdoge detected."
+  else
+    if [ "$live_media" == "usb" ]; then
+      mount -F pcfs ${live_media_path/rdsk/dsk}:c $DOGEOS_EXTRA
+    else # dvd
+      mount -F hsfs ${live_media_path/rdsk/dsk} $DOGEOS_EXTRA
+    fi
   fi
   $NODE $DOGEOS_HOME/bin/simple-pkgsrc-repo.js $DOGEOS_EXTRA/dogeos/fifo 8080 &
   echo $! >$DOGEOS_HOME/var/repo-fifo.pid
@@ -62,7 +66,9 @@ dogeosCloseResources()
   if [ -f $DOGEOS_HOME/var/repo-joyent.pid ]; then
     kill `cat $DOGEOS_HOME/var/repo-joyent.pid`
   fi
-  umount $DOGEOS_EXTRA
+  if ![ "live_media" == "smartdoge" ]; then
+    umount $DOGEOS_EXTRA
+  fi
 }
 
 dogeosCreateVm()

--- a/overlay/dogeos/bin/pxezone-install
+++ b/overlay/dogeos/bin/pxezone-install
@@ -265,6 +265,10 @@ dogeosPxeWelcome
 # decide the live media type
 dogeosFindLiveMediaType
 live_media=$val
+if [ $live_media == "smartdoge" ]; then
+  echo "PXE installer could only be used in DogeOS. Exiting."
+  exit 1
+fi
 dogeosDecideMediaDev $live_media
 live_media_path="$val"
 


### PR DESCRIPTION
smartdoge will bring dogeos's packed Fifo to normal SmartOS, which will
be convinient for sys admins having boxes can not access outside world.

smartdoge provides a simple installer script to setup the local smartos env, e.g.,

```
bash # lofiadm -a /path/to/dogeos-iso
/dev/lofi/3
bash # mkdir /opt/dogeiso
bash # mount -F hsfs /dev/lofi/3 /opt/dogeiso
bash # cd /opt/dogeiso
bash # ./smartdoge-install.sh
```

after finishing, you will have `/dogeos` and `/opt/dogeos` ready
